### PR TITLE
Get parent by checking for null subsidiary AB#592357

### DIFF
--- a/src/EPR.Calculator.FSS.API.Common.UnitTests/Services/OrganisationServiceTests.cs
+++ b/src/EPR.Calculator.FSS.API.Common.UnitTests/Services/OrganisationServiceTests.cs
@@ -246,7 +246,7 @@ public class OrganisationServiceTests
     }
 
     [TestMethod]
-    public async Task GetOrganisationsDetails_ValidRequestWithTwoOrganisations_SkipsOne_When_NoParent()
+    public async Task GetOrganisationsDetailsValidRequestWithTwoOrganisationsSkipsOneWhenNoParent()
     {
         // Arrange
         var expectedData = new List<AcceptedGrantedOrgDataResponseModel>

--- a/src/EPR.Calculator.FSS.API.Common/Services/OrganisationService.cs
+++ b/src/EPR.Calculator.FSS.API.Common/Services/OrganisationService.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+
 public class OrganisationService : IOrganisationService
 {
     private readonly SynapseDbContext _synapseDbContext;


### PR DESCRIPTION
Fix problem where parent organisations with subsidiaries were sometimes picking up the name and companies house number from one of the subsidiaries.